### PR TITLE
fix: Do not require Clone for T in MuxConnector to clone it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod tests {
         tokio::spawn(worker_a);
         tokio::spawn(worker_b);
 
-        let stream1 = connector_a.connect().unwrap();
+        let stream1 = connector_a.clone().connect().unwrap();
         let stream2 = acceptor_b.accept().await.unwrap();
         test_stream(stream1, stream2).await;
 

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -80,7 +80,6 @@ pub fn mux_connection<T: TokioConn>(
     )
 }
 
-#[derive(Clone)]
 pub struct MuxConnector<T: TokioConn> {
     state: Arc<Mutex<MuxState<T>>>,
 }
@@ -116,6 +115,14 @@ impl<T: TokioConn> MuxConnector<T> {
 
     pub fn get_num_streams(&self) -> usize {
         self.state.lock().handles.len()
+    }
+}
+
+impl<T: TokioConn> Clone for MuxConnector<T> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
Hey, thank you so much for this library. It performs very well :) 

While using it, I noticed that the compiler won't let me clone a `MuxConector<TcpStream>` instance. The `Clone` implementation created by `#[derive(Clone)]` requires T to be cloneable as well:

```
error[E0599]: the method `clone` exists for struct `MuxConnector<TcpStream>`, but its trait bounds were not satisfied
   --> src/lib.rs:113:35
    |
113 |         let stream1 = connector_a.clone().connect().unwrap();
    |                                   ^^^^^
::: /Users/oguz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.29.1/src/net/tcp/stream.rs:69:5
    |
69  |     pub struct TcpStream {
    |     -------------------- doesn't satisfy `tokio::net::TcpStream: Clone`
    |
```

So a manual clone implementation could save the day.

